### PR TITLE
fix: :bug: OpticalNodeEditor now re-renders again by using use_reacti…

### DIFF
--- a/opossum_gui/src/components/node_editor/node_config_editor.rs
+++ b/opossum_gui/src/components/node_editor/node_config_editor.rs
@@ -23,7 +23,7 @@ pub enum NodeChangeAction {
 #[component]
 pub fn NodeConfigEditor(active_node_opt: Memo<Option<(NodeType, Uuid)>>) -> Element {
     let node_properties_sig = use_signal(Properties::default);
-    println!("rerender NodeConfigEditor");
+
     use_context_provider(|| node_properties_sig);
     use_node_config_processor(node_properties_sig);
 

--- a/opossum_gui/src/components/node_editor/optical_node_editor/mod.rs
+++ b/opossum_gui/src/components/node_editor/optical_node_editor/mod.rs
@@ -15,8 +15,10 @@ use uuid::Uuid;
 
 #[component]
 pub fn OpticalNodeEditor(node_id: Uuid, node_properties_sig: Signal<Properties>) -> Element {
+    let node_id_memo = use_memo(use_reactive!(|node_id| node_id));
+    
     let resource_future = use_resource(move || async move {
-        match api::get_node_properties(node_id).await {
+        match api::get_node_properties(node_id_memo()).await {
             Ok(node_attr) => {
                 node_properties_sig.set(node_attr.properties().clone());
                 Some(node_attr)


### PR DESCRIPTION
…ve on the node_id input

Closes #631 