### PR TITLE
fix: :bug: DIrectly nested portmaps are now displayed correctly in dot

### DIFF
--- a/opossum_core/examples/nested_group_dot.rs
+++ b/opossum_core/examples/nested_group_dot.rs
@@ -1,0 +1,33 @@
+use num::Zero;
+use opossum_core::prelude::*;
+use std::path::Path;
+use uom::si::f64::Length;
+fn main() -> OpmResult<()> {
+    let mut scenery = NodeGroup::new("Nested Group Dot test");
+    let light_data_builder = LightDataBuilder::Energy(EnergyDataBuilder::LaserLines(
+        EnergyLaserLines::new(vec![(nanometer!(633.0), joule!(1.0))], nanometer!(1.0))?,
+    ));
+    let i_s = scenery.add_node(Source::new("Source", light_data_builder))?;
+
+    let mut group = NodeGroup::default();
+    let mut group2 = NodeGroup::default();
+    group.set_expand_view(true)?;
+    group2.set_expand_view(true)?;
+    let g_n1 = group2.add_node(Dummy::new("node1"))?;
+    group2.map_input_port(g_n1, "input_1", "input_1")?;
+    group2.map_output_port(g_n1, "output_1", "output_1")?;
+    let g_n3 = group.add_node(group2)?;
+
+    group.map_input_port(g_n3, "input_1", "input_1")?;
+    group.map_output_port(g_n3, "output_1", "output_1")?;
+
+    let i_g = scenery.add_node(group)?;
+    let i_d = scenery.add_node(EnergyMeter::default())?;
+
+    scenery.connect_nodes(i_s, "output_1", i_g, "input_1", Length::zero())?;
+    scenery.connect_nodes(i_g, "output_1", i_d, "input_1", Length::zero())?;
+
+    let mut doc = OpmDocument::new(scenery);
+    doc.add_analyzer(AnalyzerType::Energy);
+    doc.save_to_file(Path::new("./opossum_core/playground/nested_group_dot.opm"))
+}

--- a/opossum_core/src/dottable.rs
+++ b/opossum_core/src/dottable.rs
@@ -31,7 +31,7 @@ pub trait Dottable {
         name: &str,
         inverted: bool,
         ports: &OpticPorts,
-        rankdir: &str,
+        rankdir: &str
     ) -> OpmResult<String> {
         let inv_string = if inverted { " (inv)" } else { "" };
         let node_name = format!("{name}{inv_string}");

--- a/opossum_core/src/nodes/node_group/mod.rs
+++ b/opossum_core/src/nodes/node_group/mod.rs
@@ -509,7 +509,12 @@ impl NodeGroup {
                     "port {port_name} is not mapped"
                 )));
             };
-            Ok(format!("i{}:{}", port_info.0.as_simple(), port_info.1))
+            if let Some(node_idx) = self.graph.node_idx_by_uuid(port_info.0){
+                self.graph().create_node_edge_str(node_idx, &port_info.1)
+            }
+            else{
+                Ok(format!("i{}:{}", port_info.0.as_simple(), port_info.1))
+            }
         } else {
             Ok(format!("{node_id}:{port_name}"))
         }
@@ -841,7 +846,7 @@ impl Dottable for NodeGroup {
         name: &str,
         inverted: bool,
         ports: &OpticPorts,
-        rankdir: &str,
+        rankdir: &str
     ) -> OpmResult<String> {
         let mut cloned_group = self.clone();
         if self.node_attr.inverted() {

--- a/opossum_core/src/nodes/node_group/optic_graph/visualization.rs
+++ b/opossum_core/src/nodes/node_group/optic_graph/visualization.rs
@@ -1,9 +1,6 @@
 use super::OpticGraph;
 use crate::{
-    error::{OpmResult, OpossumError},
-    light_flow::LightFlow,
-    properties::proptype::format_quantity,
-    utils::LockExt,
+    error::{OpmResult, OpossumError}, light_flow::LightFlow, properties::proptype::format_quantity, utils::LockExt
 };
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use std::fmt::Write;
@@ -17,7 +14,7 @@ impl OpticGraph {
     /// * `light_port`:           port name that should be connected
     ///
     /// Returns the result of the edge strnig for the dot format
-    fn create_node_edge_str(&self, end_node_idx: NodeIndex, light_port: &str) -> OpmResult<String> {
+    pub fn create_node_edge_str(&self, end_node_idx: NodeIndex, light_port: &str) -> OpmResult<String> {
         let node_id = format!("i{}", self.node_by_idx(end_node_idx)?.uuid().as_simple());
         let node_ref = self.node_by_idx(end_node_idx)?;
         let mut node = node_ref.optical_ref.lock_opm()?;
@@ -55,7 +52,6 @@ impl OpticGraph {
                 .ok_or_else(|| OpossumError::Other("could not get edge_endpoints".into()))?;
             let node_id = self.node_by_idx(end_nodes.1)?.uuid();
             let dist = self.distance_from_predecessor(node_id, light.target_port())?;
-
             let src_edge_str = self.create_node_edge_str(end_nodes.0, light.src_port())?;
             let target_edge_str = self.create_node_edge_str(end_nodes.1, light.target_port())?;
 


### PR DESCRIPTION
Added a recursion within get_mapped_port_str to traverse deeply into nested port-maps in order to retrieve the correct node id for the dot file


closes #865