### PR TITLE
fix: :bug: Stabilized drop into group of nodes

### DIFF
--- a/opossum_gui/src/components/scenery_editor/node/node_component.rs
+++ b/opossum_gui/src/components/scenery_editor/node/node_component.rs
@@ -73,7 +73,7 @@ pub fn Node(
     let z_index = node.z_index();
     use_effect({
         move || {
-            if graph_state.peek().graph_info.id != *workspace.peek().active_tab.peek(){
+            if graph_state.peek().graph_info.id != *workspace.peek().active_tab.peek() {
                 return;
             }
             let mouse_pos = *mouse_pos_in_editor.read();

--- a/opossum_gui/src/components/scenery_editor/node/node_component.rs
+++ b/opossum_gui/src/components/scenery_editor/node/node_component.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
+use std::any::Any;
 use std::collections::HashSet;
 
 use super::NodeElement;
@@ -72,6 +73,9 @@ pub fn Node(
     let z_index = node.z_index();
     use_effect({
         move || {
+            if graph_state.peek().graph_info.id != *workspace.peek().active_tab.peek(){
+                return;
+            }
             let mouse_pos = *mouse_pos_in_editor.read();
             let mut droppable_group = *workspace.peek().drop_in_group.read();
             let selected_nodes = graph_store

--- a/opossum_gui/src/components/scenery_editor/node/node_component.rs
+++ b/opossum_gui/src/components/scenery_editor/node/node_component.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
-use std::any::Any;
 use std::collections::HashSet;
 
 use super::NodeElement;


### PR DESCRIPTION
Added early return of drop-in-group use_effect if the current active tab is not the graph store in use