### PR TITLE
Rename NodeAtrr::ports() -> raw_ports() to make it distinct from OpticNode::ports()

### DIFF
--- a/opossum_backend/src/nodes/ports.rs
+++ b/opossum_backend/src/nodes/ports.rs
@@ -38,7 +38,7 @@ pub async fn get_ports(
         .node_attr()
         .clone();
 
-    let ports = node_attr.ports();
+    let ports = node_attr.raw_ports();
 
     let response = NodePortsResponse {
         inputs: ports.ports(&PortType::Input).clone(),
@@ -81,7 +81,7 @@ pub async fn patch_port(
         .lock()
         .scenery_mut()
         .with_node_attr_mut(uuid, |node_attr| {
-            let port_map = node_attr.ports_mut().ports_mut(&port_type);
+            let port_map = node_attr.raw_ports_mut().ports_mut(&port_type);
 
             if let Some(port) = port_map.get_mut(&port_name) {
                 if let Some(new_aperture) = update_data.aperture {

--- a/opossum_core/src/core_optics/node_attr.rs
+++ b/opossum_core/src/core_optics/node_attr.rs
@@ -241,15 +241,24 @@ impl NodeAttr {
     pub const fn set_inverted(&mut self, inverted: bool) {
         self.inverted = inverted;
     }
-    /// Returns a reference to the optic ports of this [`NodeAttr`].
+    /// Returns a reference to the stored optic ports of this [`NodeAttr`].
+    ///
+    /// **Warning**: This method only returns the internally stored port configuration.
+    /// For virtual nodes like [`NodeReference`](crate::nodes::NodeReference), this might be empty. To get the
+    /// effective ports of an optical element, always use the `ports()` method
+    /// of the [`OpticNode`](crate::core_optics::OpticNode) trait instead!
     #[must_use]
-    pub const fn ports(&self) -> &OpticPorts {
+    pub const fn raw_ports(&self) -> &OpticPorts {
         &self.ports
     }
 
     /// Returns a mutable reference to the optic ports of this [`NodeAttr`].
+    ///
+    /// **Warning**: See [`raw_ports()`](NodeAttr::raw_ports). Use 
+    /// the [`OpticNode`](crate::core_optics::OpticNode) trait methods for
+    /// safe modifications of effective ports.
     #[must_use]
-    pub const fn ports_mut(&mut self) -> &mut OpticPorts {
+    pub const fn raw_ports_mut(&mut self) -> &mut OpticPorts {
         &mut self.ports
     }
     /// Sets the apertures of this [`NodeAttr`].

--- a/opossum_core/src/core_optics/optic_node.rs
+++ b/opossum_core/src/core_optics/optic_node.rs
@@ -215,7 +215,7 @@ pub trait OpticNode: Dottable {
     }
     /// Return the available (input & output) ports of this [`OpticNode`].
     fn ports(&self) -> OpticPorts {
-        let mut ports = self.node_attr().ports().clone();
+        let mut ports = self.node_attr().raw_ports().clone();
         if self.node_attr().inverted() {
             ports.set_inverted(true);
         }
@@ -225,7 +225,7 @@ pub trait OpticNode: Dottable {
     /// Return the available (input & output) ports of this [`OpticNode`] as mutables.
     fn ports_mut(&mut self) -> &mut OpticPorts {
         let inverted = self.node_attr().inverted();
-        let ports = self.node_attr_mut().ports_mut();
+        let ports = self.node_attr_mut().raw_ports_mut();
         if inverted {
             ports.set_inverted(true);
         }
@@ -469,7 +469,7 @@ pub trait OpticNode: Dottable {
             node_attr_mut.set_align_like_node_at_distance(*node_idx, *distance);
         }
         node_attr_mut.update_properties(node_attributes.properties().clone());
-        node_attr_mut.set_ports(node_attributes.ports().clone());
+        node_attr_mut.set_ports(node_attributes.raw_ports().clone());
         node_attr_mut.set_uuid(node_attributes.uuid());
         node_attr_mut.set_gui_position(node_attributes.gui_position());
         Ok(())

--- a/opossum_core/src/nodes/node_group/mod.rs
+++ b/opossum_core/src/nodes/node_group/mod.rs
@@ -924,7 +924,7 @@ impl NodeGroup {
 impl OpticNode for NodeGroup {
     fn ports(&self) -> OpticPorts {
         let mut ports = OpticPorts::new();
-        let ports_to_be_set = self.node_attr.ports();
+        let ports_to_be_set = self.node_attr.raw_ports();
         for p in self.graph.port_map(&PortType::Input).port_names() {
             ports.add(&PortType::Input, &p).unwrap();
         }


### PR DESCRIPTION
Closes #911