### PR TITLE
1113 dropping or pasting a group reference node into the group it is refering to must be forbidden

### DIFF
--- a/doc/book/src/concepts/optical_graph.md
+++ b/doc/book/src/concepts/optical_graph.md
@@ -63,3 +63,5 @@ This structure is physically nonsensical and becomes unmanageable with complex r
 To solve this, OPOSSUM uses **Reference Nodes**. A reference node contains only a reference to another existing node and behaves exactly like the node it references. This allows a linear resonator to be "unrolled" in the graph, effectively translating it into a ring resonator structure without topological ambiguity.
 
 > **Note:** Strictly speaking, light in a ring resonator can propagate in both directions (unless suppressed by optical components). Since we use a directed graph, only one direction can be modelled at a time. Solutions for bidirectional propagation are currently being [investigated](https://git.gsi.de/phelix/rust/opossum/-/issues/2).
+
+> **Note:** A reference node that refers to a group must not be placed inside that same group, or inside any group nested within it. This would make the group depend on its own reference, which OPOSSUM rejects when creating, moving, cutting, or pasting the reference node.

--- a/doc/book/src/reference/nodes.md
+++ b/doc/book/src/reference/nodes.md
@@ -11,7 +11,8 @@ Nodes form the building blocks of the optical model and normally represent optic
 - [Reference node](./nodes/reference_node.md)
 
     A reference node refers to an already existing node in the model. Reference nodes are necessary in multi pass setups.
-    Another use case is the modeling of linear resonators.
+    Another use case is the modeling of linear resonators. A reference to a group must not be placed inside that same
+    group or any group nested within it (see [Reference node](./nodes/reference_node.md)).
 
 ## Node Properties
 

--- a/doc/book/src/reference/nodes/reference_node.md
+++ b/doc/book/src/reference/nodes/reference_node.md
@@ -2,6 +2,10 @@
 
 ![Reference node icon](../images/icons/node_unknown.svg)
 
+## Key Usage Considerations
+
+- **Placement restriction**: A reference to a group node must not be placed inside that same group, or inside any group nested within it, at any depth. Doing so would make the group depend on its own reference, which is rejected when creating, moving, cutting, or pasting a reference node. hence, this operation is prohibited.
+
 ## Analysis
 
 ## Ports

--- a/opossum_backend/src/helper_functions/graph_lookup.rs
+++ b/opossum_backend/src/helper_functions/graph_lookup.rs
@@ -2,13 +2,14 @@ use actix_web::web::{self};
 use nalgebra::Point2;
 use opossum_core::{
     core_optics::{NodeAttrExt, OpticRef, node_attr::HasNodeAttr},
-    error::OpmResult,
+    error::{OpmResult, OpossumError},
     nodes::{ConnectionInfo, NodeGroup},
     opm_document::OpmDocument,
     prelude::{PortType, Proptype},
     types::api_types::{ConnectInfo, NodeInfo},
     utils::LockExt,
 };
+use std::collections::HashSet;
 use uuid::Uuid;
 
 use crate::{app_state::AppState, error::BackEndErrorResponse};
@@ -228,6 +229,96 @@ pub fn lowest_common_ancestor_group(scenery: &NodeGroup, a: Uuid, b: Uuid) -> Op
         .unwrap_or_else(|| scenery.node_attr().uuid()))
 }
 
+/// Returns whether `candidate_ancestor` is `node_id` itself, or one of `node_id`'s ancestor groups (i.e.
+/// `node_id` is nested inside `candidate_ancestor` at any depth).
+///
+/// # Errors
+///
+/// Returns an error if `node_id` (or an ancestor of it) doesn't resolve to a node in `scenery`.
+fn is_ancestor_or_self(
+    scenery: &NodeGroup,
+    candidate_ancestor: Uuid,
+    node_id: Uuid,
+) -> OpmResult<bool> {
+    Ok(ancestor_chain(scenery, node_id)?.contains(&candidate_ancestor))
+}
+
+/// Returns an error if placing/keeping a reference to `target_id` inside `destination_group_id` would nest
+/// the reference inside its own target group, or a group nested within it.
+///
+/// Analyzing a [`NodeGroup`] holds that group's `Mutex` for the entire duration of its recursive descent
+/// into its members. A [`NodeReference`](opossum_core::nodes::NodeReference) nested anywhere inside its
+/// own target's subtree would, when analysis reaches it, try to lock that same already-held `Mutex` again
+/// on the same thread - a guaranteed self-deadlock. This guards against creating that configuration via
+/// direct reference creation, drag-and-drop move, cut, or paste.
+///
+/// # Errors
+///
+/// Returns an error if `target_id` is `destination_group_id` itself, or an ancestor of it. Also returns an
+/// error if `destination_group_id` (or an ancestor of it) doesn't resolve to a node in `scenery`.
+pub fn check_reference_target_not_nested(
+    scenery: &NodeGroup,
+    target_id: Uuid,
+    destination_group_id: Uuid,
+) -> OpmResult<()> {
+    if is_ancestor_or_self(scenery, target_id, destination_group_id)? {
+        return Err(OpossumError::OpticGroup(format!(
+            "cannot place a reference to <{target_id}> inside its own target group or a group nested within it"
+        )));
+    }
+    Ok(())
+}
+
+/// Returns an error if relocating/pasting `root_ids` - and everything nested inside any of them - into
+/// `destination_group_id` would place a `NodeReference` inside its own target group (see
+/// [`check_reference_target_not_nested`]).
+///
+/// A reference whose target is itself part of the expanded `root_ids` set (reference and target being
+/// relocated/pasted together) is skipped: they move together as a rigid unit, so their relative structure -
+/// and thus this check's outcome - can't change as a result of this particular relocation. An id that
+/// doesn't currently resolve in `scenery` is silently skipped, mirroring the existing tolerance for stale
+/// ids elsewhere in the relocation/paste machinery.
+///
+/// # Errors
+///
+/// Returns an error if a reference among `root_ids` (or nested within one of them) targets
+/// `destination_group_id` itself or a group nested within it.
+pub fn validate_relocated_references(
+    scenery: &NodeGroup,
+    root_ids: &[Uuid],
+    destination_group_id: Uuid,
+) -> OpmResult<()> {
+    let mut relocating_ids: Vec<Uuid> = root_ids.to_vec();
+    for id in root_ids {
+        let Ok((optic_ref, _)) = scenery.node_recursive(*id) else {
+            continue;
+        };
+        let Ok(node) = optic_ref.optical_ref.lock_opm() else {
+            continue;
+        };
+        if let Some(group) = node.as_any().downcast_ref::<NodeGroup>() {
+            relocating_ids.extend(group.collect_all_contained_node_ids_recursive()?);
+        }
+    }
+    let relocating_set: HashSet<Uuid> = relocating_ids.iter().copied().collect();
+
+    for id in &relocating_ids {
+        let target_id_opt = scenery
+            .with_node_attr(*id, |attr| match attr.properties().get("reference id") {
+                Ok(Proptype::Uuid(target)) => Some(*target),
+                _ => None,
+            })
+            .ok()
+            .flatten();
+        if let Some(target_id) = target_id_opt
+            && !relocating_set.contains(&target_id)
+        {
+            check_reference_target_not_nested(scenery, target_id, destination_group_id)?;
+        }
+    }
+    Ok(())
+}
+
 /// Create a [`NodeInfo`] representation for a newly created group node.
 ///
 /// # Arguments
@@ -258,4 +349,118 @@ pub fn create_new_group_node_info(
         &*new_group_node,
         Some(Some((pos.x, pos.y))),
     ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use opossum_core::nodes::{Dummy, NodeReference};
+
+    /// Builds `root -> g1 -> g2`, returning `(root, g1_id, g2_id)`.
+    fn nested_groups() -> (NodeGroup, Uuid, Uuid) {
+        let mut root = NodeGroup::new("root");
+        let mut g2 = NodeGroup::new("g2");
+        g2.add_node(Dummy::default()).unwrap();
+        let mut g1 = NodeGroup::new("g1");
+        let g2_id = g1.add_node(g2).unwrap();
+        let g1_id = root.add_node(g1).unwrap();
+        (root, g1_id, g2_id)
+    }
+
+    #[test]
+    fn is_ancestor_or_self_true_for_self() {
+        let (root, g1_id, _) = nested_groups();
+        assert!(is_ancestor_or_self(&root, g1_id, g1_id).unwrap());
+    }
+
+    #[test]
+    fn is_ancestor_or_self_true_for_direct_parent() {
+        let (root, g1_id, g2_id) = nested_groups();
+        assert!(is_ancestor_or_self(&root, g1_id, g2_id).unwrap());
+    }
+
+    #[test]
+    fn is_ancestor_or_self_true_for_root_grandparent() {
+        let (root, _, g2_id) = nested_groups();
+        let root_id = root.node_attr().uuid();
+        assert!(is_ancestor_or_self(&root, root_id, g2_id).unwrap());
+    }
+
+    #[test]
+    fn is_ancestor_or_self_false_for_unrelated_group() {
+        let (mut root, _, g2_id) = nested_groups();
+        let other_id = root.add_node(NodeGroup::new("other")).unwrap();
+        assert!(!is_ancestor_or_self(&root, other_id, g2_id).unwrap());
+    }
+
+    #[test]
+    fn check_reference_target_not_nested_rejects_self_placement() {
+        let (root, g1_id, _) = nested_groups();
+        assert!(check_reference_target_not_nested(&root, g1_id, g1_id).is_err());
+    }
+
+    #[test]
+    fn check_reference_target_not_nested_rejects_nested_descendant() {
+        let (root, g1_id, g2_id) = nested_groups();
+        assert!(check_reference_target_not_nested(&root, g1_id, g2_id).is_err());
+    }
+
+    #[test]
+    fn check_reference_target_not_nested_allows_unrelated_group() {
+        let (mut root, g1_id, _) = nested_groups();
+        let other_id = root.add_node(NodeGroup::new("other")).unwrap();
+        assert!(check_reference_target_not_nested(&root, g1_id, other_id).is_ok());
+    }
+
+    #[test]
+    fn validate_relocated_references_rejects_reference_into_own_target() {
+        let mut root = NodeGroup::new("root");
+        let g1_id = root.add_node(NodeGroup::new("g1")).unwrap();
+        let g1_ref = root.node(g1_id).unwrap();
+        let node_reference = NodeReference::from_node(&g1_ref).unwrap();
+        let ref_id = root.add_node(node_reference).unwrap();
+
+        assert!(validate_relocated_references(&root, &[ref_id], g1_id).is_err());
+    }
+
+    #[test]
+    fn validate_relocated_references_rejects_reference_nested_in_moved_group() {
+        // root -> T, root -> H { ref(T) }: moving H into T would nest ref(T) inside its own target.
+        let mut root = NodeGroup::new("root");
+        let t_id = root.add_node(NodeGroup::new("T")).unwrap();
+        let t_ref = root.node(t_id).unwrap();
+        let node_reference = NodeReference::from_node(&t_ref).unwrap();
+
+        let mut h = NodeGroup::new("H");
+        h.add_node(node_reference).unwrap();
+        let h_id = root.add_node(h).unwrap();
+
+        assert!(validate_relocated_references(&root, &[h_id], t_id).is_err());
+    }
+
+    #[test]
+    fn validate_relocated_references_allows_sibling_reference() {
+        let mut root = NodeGroup::new("root");
+        let a_id = root.add_node(Dummy::default()).unwrap();
+        let a_ref = root.node(a_id).unwrap();
+        let node_reference = NodeReference::from_node(&a_ref).unwrap();
+        let ref_id = root.add_node(node_reference).unwrap();
+        let other_id = root.add_node(NodeGroup::new("other")).unwrap();
+
+        assert!(validate_relocated_references(&root, &[ref_id], other_id).is_ok());
+    }
+
+    #[test]
+    fn validate_relocated_references_skips_co_relocated_target() {
+        // Moving a reference and its own target together, as siblings, into an unrelated destination
+        // must still be allowed - they keep the same (valid) relative structure either way.
+        let mut root = NodeGroup::new("root");
+        let g1_id = root.add_node(NodeGroup::new("g1")).unwrap();
+        let g1_ref = root.node(g1_id).unwrap();
+        let node_reference = NodeReference::from_node(&g1_ref).unwrap();
+        let ref_id = root.add_node(node_reference).unwrap();
+        let dest_id = root.add_node(NodeGroup::new("dest")).unwrap();
+
+        assert!(validate_relocated_references(&root, &[g1_id, ref_id], dest_id).is_ok());
+    }
 }

--- a/opossum_backend/src/helper_functions/mod.rs
+++ b/opossum_backend/src/helper_functions/mod.rs
@@ -16,9 +16,10 @@ pub use connection_classification::{build_connect_info, reconnect_all, split_sor
 pub use connection_preservation::PreservedConnections;
 pub use content_negotiation::{Ron, ron_or_json_response};
 pub use graph_lookup::{
-    capture_node_connections, collect_group_connections, collect_node_refs_and_pos,
-    create_new_group_node_info, is_reference_target, lowest_common_ancestor_group, map_port,
-    parent_group_id_or_self, resolve_reference_chain,
+    capture_node_connections, check_reference_target_not_nested, collect_group_connections,
+    collect_node_refs_and_pos, create_new_group_node_info, is_reference_target,
+    lowest_common_ancestor_group, map_port, parent_group_id_or_self, resolve_reference_chain,
+    validate_relocated_references,
 };
 pub use handler_support::{analyzer_mut_or_404, apply_and_push_undo};
 pub use port_map_cascade::{

--- a/opossum_backend/src/helper_functions/relocation.rs
+++ b/opossum_backend/src/helper_functions/relocation.rs
@@ -9,6 +9,7 @@ use super::{
     connection_preservation::{
         PreservedConnections, disconnect_moved_node_connections, reconnect_moved_node_connections,
     },
+    graph_lookup::validate_relocated_references,
     port_map_cascade::{PortMapCascadeRemoval, disconnect_exposed_port_cascades_for_node},
 };
 
@@ -63,13 +64,17 @@ pub struct RelocationOutcome {
 ///
 /// # Errors
 ///
-/// Returns an error if either group id doesn't resolve, or a moved node's uuid can't be found.
+/// Returns an error if either group id doesn't resolve, a moved node's uuid can't be found, or the move
+/// would place a `NodeReference` inside its own target group (or a group nested within it) - see
+/// [`validate_relocated_references`].
 pub fn relocate_nodes_in_document(
     document: &mut OpmDocument,
     from_group_id: Uuid,
     to_group_id: Uuid,
     node_ids: &[Uuid],
 ) -> OpmResult<RelocationOutcome> {
+    validate_relocated_references(document.scenery(), node_ids, to_group_id)?;
+
     let connections = document
         .scenery()
         .with_group_node(from_group_id, NodeGroup::connections)?;
@@ -260,14 +265,18 @@ pub struct CutRelocationOutcome {
 ///
 /// # Errors
 ///
-/// Returns an error if either group id doesn't resolve, a moved node's uuid can't be found, or a
-/// severing / connection step fails.
+/// Returns an error if either group id doesn't resolve, a moved node's uuid can't be found, a
+/// severing / connection step fails, or the relocation would place a `NodeReference` inside its own
+/// target group (or a group nested within it) - see
+/// [`validate_relocated_references`].
 pub fn relocate_nodes_severing_external_links(
     document: &mut OpmDocument,
     from_group_id: Uuid,
     to_group_id: Uuid,
     node_ids: &[Uuid],
 ) -> OpmResult<CutRelocationOutcome> {
+    validate_relocated_references(document.scenery(), node_ids, to_group_id)?;
+
     let SeveredLinksOutcome {
         removed_connections,
         cascades,

--- a/opossum_backend/src/nodes/core.rs
+++ b/opossum_backend/src/nodes/core.rs
@@ -24,8 +24,9 @@ use crate::{
     error::BackEndErrorResponse,
     helper_functions::{
         PortMapCascadeRemoval, apply_and_push_undo, capture_node_connections,
-        disconnect_exposed_port_cascades_for_node, parent_group_id_or_self,
-        resolve_reference_chain, ron_or_json_response, split_cascades_for_response,
+        check_reference_target_not_nested, disconnect_exposed_port_cascades_for_node,
+        parent_group_id_or_self, resolve_reference_chain, ron_or_json_response,
+        split_cascades_for_response,
     },
     undo::{
         CascadedNode, Command, NodeSnapshot, PatchAnalyzer, PatchNode, capture_old_node_request,
@@ -681,6 +682,7 @@ async fn post_reference(
 
     let mut document = data.document.lock();
     let (referring_node, _) = resolve_reference_chain(&document, ref_node_info.referring_node())?;
+    check_reference_target_not_nested(document.scenery(), referring_node.uuid()?, group_uuid)?;
     let mut node_reference = NodeReference::from_node(&referring_node)?;
 
     node_reference
@@ -1705,6 +1707,115 @@ mod test {
                 .node_recursive(ref_uuid)
                 .is_ok(),
             "redo must restore the reference node under the same uuid"
+        );
+    }
+
+    /// Regression test for the bug where creating a reference directly inside its own target group froze
+    /// the analyzer: analyzing a group holds its `Mutex` for the duration of its own recursive descent
+    /// into its members, so a `NodeReference` resolving back to an already-locked ancestor group
+    /// self-deadlocks. Asserts `post_reference` now rejects placing a reference to `G` inside `G` itself.
+    #[actix_web::test]
+    async fn test_post_reference_rejects_reference_into_own_target() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let group_id = {
+            let mut document = app_state.document.lock();
+            document
+                .scenery_mut()
+                .add_node(NodeGroup::new("G"))
+                .unwrap()
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_reference),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/{group_id}/references"))
+            .set_json(&NewRefNode::new(group_id, (0.0, 0.0)))
+            .to_request();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "creating a reference to a group inside that very group must be rejected"
+        );
+    }
+
+    /// Same hazard, one level deeper: `G1` contains `G2`; a reference to `G1` must also be rejected when
+    /// placed inside `G2`, since `G2` lives inside `G1`'s own subtree too.
+    #[actix_web::test]
+    async fn test_post_reference_rejects_reference_into_nested_descendant_of_target() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let (g1_id, g2_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let mut g2 = NodeGroup::new("G2");
+            g2.add_node(Dummy::default()).unwrap();
+            let mut g1 = NodeGroup::new("G1");
+            let g2_id = g1.add_node(g2).unwrap();
+            let g1_id = scenery.add_node(g1).unwrap();
+            (g1_id, g2_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_reference),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/{g2_id}/references"))
+            .set_json(&NewRefNode::new(g1_id, (0.0, 0.0)))
+            .to_request();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "creating a reference to G1 inside G1's own nested descendant G2 must be rejected"
+        );
+    }
+
+    /// A reference to a group placed as a *sibling* (not nested inside it) must still succeed - this is
+    /// the sanctioned resonator/double-pass pattern (see `NodeReference`'s own doc comment), not the
+    /// hazardous nested case the two tests above guard against.
+    #[actix_web::test]
+    async fn test_post_reference_allows_reference_to_unrelated_group() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let (root_id, g1_id) = {
+            let mut document = app_state.document.lock();
+            let root_id = document.scenery().node_attr().uuid();
+            let mut g1 = NodeGroup::new("G1");
+            g1.add_node(Dummy::default()).unwrap();
+            let g1_id = document.scenery_mut().add_node(g1).unwrap();
+            (root_id, g1_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_reference),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/{root_id}/references"))
+            .set_json(&NewRefNode::new(g1_id, (0.0, 0.0)))
+            .to_request();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "a reference to a group placed as its sibling must still be allowed"
         );
     }
 

--- a/opossum_backend/src/operations/cut.rs
+++ b/opossum_backend/src/operations/cut.rs
@@ -1136,4 +1136,165 @@ mod test {
         );
         assert!(a_to_g_edge(&app_state), "undo must restore the A -> G edge");
     }
+
+    /// Regression test for the bug where nothing stopped a reference to a group from being cut into that
+    /// very group - which deadlocks the analyzer (analyzing a group holds its `Mutex` for the duration of
+    /// its own recursive descent, so a reference resolving back to an already-locked ancestor
+    /// self-deadlocks). Builds `G` and a sibling `R = ref(G)` at the root, copies `R`, then asserts cutting
+    /// it into `G` is rejected and `R` stays at the root.
+    #[actix_web::test]
+    async fn test_cut_reference_into_own_target_is_rejected() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let (root_id, g_id, ref_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let root_id = scenery.node_attr().uuid();
+            let g_id = scenery.add_node(NodeGroup::new("G")).unwrap();
+            let g_ref = scenery.node(g_id).unwrap();
+            let node_reference = NodeReference::from_node(&g_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            (root_id, g_id, ref_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_copy_nodes)
+                .service(post_cut_nodes),
+        )
+        .await;
+
+        let mut nodes_to_copy = HashSet::new();
+        nodes_to_copy.insert(ref_id);
+        let req = test::TestRequest::post()
+            .uri("/copy_nodes")
+            .set_json(&nodes_to_copy)
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::NO_CONTENT
+        );
+
+        let req = test::TestRequest::post()
+            .uri("/cut_nodes")
+            .set_json(&(g_id, (50.0, 50.0)))
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::BAD_REQUEST,
+            "cutting a reference into its own target group must be rejected"
+        );
+        assert!(
+            app_state
+                .document
+                .lock()
+                .scenery()
+                .node_recursive(ref_id)
+                .is_ok_and(|(_, parent)| parent == root_id),
+            "the rejected reference must remain at its original location"
+        );
+    }
+
+    /// Same hazard, one level deeper: `G1` contains `G2`; a reference to `G1` sitting at the root must
+    /// also be rejected when cut into `G2`, since `G2` lives inside `G1`'s own subtree too.
+    #[actix_web::test]
+    async fn test_cut_reference_into_nested_descendant_of_target_is_rejected() {
+        use opossum_core::nodes::{Dummy, NodeGroup};
+
+        let app_state = Data::new(AppState::default());
+        let (g2_id, ref_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let mut g2 = NodeGroup::new("G2");
+            g2.add_node(Dummy::default()).unwrap();
+            let mut g1 = NodeGroup::new("G1");
+            let g2_id = g1.add_node(g2).unwrap();
+            let g1_id = scenery.add_node(g1).unwrap();
+            let g1_ref = scenery.node(g1_id).unwrap();
+            let node_reference = NodeReference::from_node(&g1_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            (g2_id, ref_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_copy_nodes)
+                .service(post_cut_nodes),
+        )
+        .await;
+
+        let mut nodes_to_copy = HashSet::new();
+        nodes_to_copy.insert(ref_id);
+        let req = test::TestRequest::post()
+            .uri("/copy_nodes")
+            .set_json(&nodes_to_copy)
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::NO_CONTENT
+        );
+
+        let req = test::TestRequest::post()
+            .uri("/cut_nodes")
+            .set_json(&(g2_id, (50.0, 50.0)))
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::BAD_REQUEST,
+            "cutting a reference into a nested descendant of its target must be rejected"
+        );
+    }
+
+    /// A reference and its own target cut together, as siblings, into an unrelated destination group must
+    /// still succeed - they keep the same (valid) relative structure either way, unlike the two rejected
+    /// cases above.
+    #[actix_web::test]
+    async fn test_cut_reference_and_target_together_as_siblings_is_allowed() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let (g_id, ref_id, dest_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let g_id = scenery.add_node(NodeGroup::new("G")).unwrap();
+            let g_ref = scenery.node(g_id).unwrap();
+            let node_reference = NodeReference::from_node(&g_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            let dest_id = scenery.add_node(NodeGroup::new("dest")).unwrap();
+            (g_id, ref_id, dest_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_copy_nodes)
+                .service(post_cut_nodes),
+        )
+        .await;
+
+        let mut nodes_to_copy = HashSet::new();
+        nodes_to_copy.insert(g_id);
+        nodes_to_copy.insert(ref_id);
+        let req = test::TestRequest::post()
+            .uri("/copy_nodes")
+            .set_json(&nodes_to_copy)
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::NO_CONTENT
+        );
+
+        let req = test::TestRequest::post()
+            .uri("/cut_nodes")
+            .set_json(&(dest_id, (50.0, 50.0)))
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::OK,
+            "cutting a reference together with its own target as siblings must still be allowed"
+        );
+    }
 }

--- a/opossum_backend/src/operations/move_nodes.rs
+++ b/opossum_backend/src/operations/move_nodes.rs
@@ -527,4 +527,142 @@ mod test {
             "redo of the same move must focus the same outer tab, not jump into the group"
         );
     }
+
+    /// Regression test for the bug where nothing stopped a reference to a group from being moved into
+    /// that very group - which deadlocks the analyzer (analyzing a group holds its `Mutex` for the
+    /// duration of its own recursive descent, so a reference resolving back to an already-locked ancestor
+    /// self-deadlocks). Builds `G` and a sibling `R = ref(G)` at the root, then asserts moving `R` into
+    /// `G` is rejected and `R` stays put.
+    #[actix_web::test]
+    async fn test_move_reference_into_own_target_is_rejected() {
+        use opossum_core::nodes::{NodeGroup, NodeReference};
+
+        let app_state = Data::new(AppState::default());
+        let (root_id, g_id, ref_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let root_id = scenery.node_attr().uuid();
+            let g_id = scenery.add_node(NodeGroup::new("G")).unwrap();
+            let g_ref = scenery.node(g_id).unwrap();
+            let node_reference = NodeReference::from_node(&g_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            (root_id, g_id, ref_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_move_nodes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/move_nodes")
+            .set_json(&MoveNodesRequest {
+                source_group_id: root_id,
+                target_group_id: g_id,
+                nodes_to_move: vec![ref_id],
+            })
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::BAD_REQUEST,
+            "moving a reference into its own target group must be rejected"
+        );
+        assert!(
+            app_state
+                .document
+                .lock()
+                .scenery()
+                .node_recursive(ref_id)
+                .is_ok_and(|(_, parent)| parent == root_id),
+            "the rejected reference must remain at its original location"
+        );
+    }
+
+    /// Same hazard, one level deeper: `G1` contains `G2`; a reference to `G1` sitting at the root must
+    /// also be rejected when moved into `G2`, since `G2` lives inside `G1`'s own subtree too.
+    #[actix_web::test]
+    async fn test_move_reference_into_nested_descendant_of_target_is_rejected() {
+        use opossum_core::nodes::{Dummy, NodeGroup, NodeReference};
+
+        let app_state = Data::new(AppState::default());
+        let (root_id, g2_id, ref_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let root_id = scenery.node_attr().uuid();
+            let mut g2 = NodeGroup::new("G2");
+            g2.add_node(Dummy::default()).unwrap();
+            let mut g1 = NodeGroup::new("G1");
+            let g2_id = g1.add_node(g2).unwrap();
+            let g1_id = scenery.add_node(g1).unwrap();
+            let g1_ref = scenery.node(g1_id).unwrap();
+            let node_reference = NodeReference::from_node(&g1_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            (root_id, g2_id, ref_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_move_nodes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/move_nodes")
+            .set_json(&MoveNodesRequest {
+                source_group_id: root_id,
+                target_group_id: g2_id,
+                nodes_to_move: vec![ref_id],
+            })
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::BAD_REQUEST,
+            "moving a reference into a nested descendant of its target must be rejected"
+        );
+    }
+
+    /// A reference and its own target moved together, as siblings, into an unrelated destination group
+    /// must still succeed - they keep the same (valid) relative structure either way, unlike the two
+    /// rejected cases above.
+    #[actix_web::test]
+    async fn test_move_reference_and_target_together_as_siblings_is_allowed() {
+        use opossum_core::nodes::{NodeGroup, NodeReference};
+
+        let app_state = Data::new(AppState::default());
+        let (root_id, g_id, ref_id, dest_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let root_id = scenery.node_attr().uuid();
+            let g_id = scenery.add_node(NodeGroup::new("G")).unwrap();
+            let g_ref = scenery.node(g_id).unwrap();
+            let node_reference = NodeReference::from_node(&g_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            let dest_id = scenery.add_node(NodeGroup::new("dest")).unwrap();
+            (root_id, g_id, ref_id, dest_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_move_nodes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/move_nodes")
+            .set_json(&MoveNodesRequest {
+                source_group_id: root_id,
+                target_group_id: dest_id,
+                nodes_to_move: vec![g_id, ref_id],
+            })
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::OK,
+            "moving a reference together with its own target as siblings must still be allowed"
+        );
+    }
 }

--- a/opossum_backend/src/operations/paste.rs
+++ b/opossum_backend/src/operations/paste.rs
@@ -22,6 +22,7 @@ use crate::{
     error::BackEndErrorResponse,
     helper_functions::{
         build_connect_info, capture_node_connections, map_port, parent_group_id_or_self,
+        validate_relocated_references,
     },
     undo::{CascadedNode, Command, EdgeSnapshot, NodeSnapshot},
 };
@@ -297,6 +298,11 @@ fn build_paste_undo_batch(
 /// This function duplicates the nodes/analyzers currently in the copy cache into the target group,
 /// minting a fresh uuid for each copy. Moving nodes without duplicating them (a "cut") is a separate
 /// operation - see [`post_cut_nodes`](super::cut::post_cut_nodes).
+///
+/// Rejected (before anything is inserted, so the copy cache is left intact for a retry elsewhere) if a
+/// copied `NodeReference` - uncopied targets aren't duplicated, so it would still resolve to the same live
+/// target - would end up nested inside its own target group, or a group nested within it; see
+/// [`validate_relocated_references`].
 #[utoipa::path(tag = "operations",
     request_body(content = (Uuid, (f64, f64)),
         description = "Uuid of the group node to be pasted in, and the position at which the node should be pasted",
@@ -333,6 +339,12 @@ pub(super) async fn post_paste_nodes(
     }
 
     let mut document = data.document.lock();
+    let root_ids: Vec<Uuid> = copied_optical_nodes
+        .iter()
+        .filter_map(|r| r.uuid().ok())
+        .collect();
+    validate_relocated_references(document.scenery(), &root_ids, paste_group_id)?;
+
     let PastedNodes {
         grouped_node_infos,
         grouped_connect_info,
@@ -1222,6 +1234,167 @@ mod test {
         assert!(
             output_names.contains(&"g1_ext_out".to_string()),
             "the pasted G1's external output port must be restored"
+        );
+    }
+
+    /// Regression test for the bug where nothing stopped a reference to a group from being pasted into
+    /// that very group - which deadlocks the analyzer (analyzing a group holds its `Mutex` for the
+    /// duration of its own recursive descent, so a reference resolving back to an already-locked ancestor
+    /// self-deadlocks). Copies `R = ref(G)` alone (leaving `G` uncopied, so the paste would still resolve
+    /// to the same live `G`) and asserts pasting it into `G` is rejected, with nothing inserted.
+    #[actix_web::test]
+    async fn test_paste_reference_into_own_target_is_rejected() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let (g_id, ref_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let g_id = scenery.add_node(NodeGroup::new("G")).unwrap();
+            let g_ref = scenery.node(g_id).unwrap();
+            let node_reference = NodeReference::from_node(&g_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            (g_id, ref_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_copy_nodes)
+                .service(post_paste_nodes),
+        )
+        .await;
+
+        let mut nodes_to_copy = HashSet::new();
+        nodes_to_copy.insert(ref_id);
+        let req = test::TestRequest::post()
+            .uri("/copy_nodes")
+            .set_json(&nodes_to_copy)
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::NO_CONTENT
+        );
+
+        let req = test::TestRequest::post()
+            .uri("/paste_nodes")
+            .set_json(&(g_id, (0.0, 0.0)))
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::BAD_REQUEST,
+            "pasting a reference into its own target group must be rejected"
+        );
+        assert_eq!(
+            app_state
+                .document
+                .lock()
+                .scenery()
+                .with_group_node(g_id, NodeGroup::nr_of_nodes)
+                .unwrap(),
+            0,
+            "nothing must have been inserted into the target group"
+        );
+    }
+
+    /// Same hazard, one level deeper: `G1` contains `G2`; a reference to `G1` sitting at the root must
+    /// also be rejected when pasted into `G2`, since `G2` lives inside `G1`'s own subtree too.
+    #[actix_web::test]
+    async fn test_paste_reference_into_nested_descendant_of_target_is_rejected() {
+        use opossum_core::nodes::{Dummy, NodeGroup};
+
+        let app_state = Data::new(AppState::default());
+        let (g2_id, ref_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let mut g2 = NodeGroup::new("G2");
+            g2.add_node(Dummy::default()).unwrap();
+            let mut g1 = NodeGroup::new("G1");
+            let g2_id = g1.add_node(g2).unwrap();
+            let g1_id = scenery.add_node(g1).unwrap();
+            let g1_ref = scenery.node(g1_id).unwrap();
+            let node_reference = NodeReference::from_node(&g1_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            (g2_id, ref_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_copy_nodes)
+                .service(post_paste_nodes),
+        )
+        .await;
+
+        let mut nodes_to_copy = HashSet::new();
+        nodes_to_copy.insert(ref_id);
+        let req = test::TestRequest::post()
+            .uri("/copy_nodes")
+            .set_json(&nodes_to_copy)
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::NO_CONTENT
+        );
+
+        let req = test::TestRequest::post()
+            .uri("/paste_nodes")
+            .set_json(&(g2_id, (0.0, 0.0)))
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::BAD_REQUEST,
+            "pasting a reference into a nested descendant of its target must be rejected"
+        );
+    }
+
+    /// A reference and its own target copied and pasted together, as siblings, into an unrelated
+    /// destination group must still succeed - they keep the same (valid) relative structure either way,
+    /// unlike the two rejected cases above.
+    #[actix_web::test]
+    async fn test_paste_reference_and_target_together_as_siblings_is_allowed() {
+        use opossum_core::nodes::NodeGroup;
+
+        let app_state = Data::new(AppState::default());
+        let (g_id, ref_id, dest_id) = {
+            let mut document = app_state.document.lock();
+            let scenery = document.scenery_mut();
+            let g_id = scenery.add_node(NodeGroup::new("G")).unwrap();
+            let g_ref = scenery.node(g_id).unwrap();
+            let node_reference = NodeReference::from_node(&g_ref).unwrap();
+            let ref_id = scenery.add_node(node_reference).unwrap();
+            let dest_id = scenery.add_node(NodeGroup::new("dest")).unwrap();
+            (g_id, ref_id, dest_id)
+        };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(post_copy_nodes)
+                .service(post_paste_nodes),
+        )
+        .await;
+
+        let mut nodes_to_copy = HashSet::new();
+        nodes_to_copy.insert(g_id);
+        nodes_to_copy.insert(ref_id);
+        let req = test::TestRequest::post()
+            .uri("/copy_nodes")
+            .set_json(&nodes_to_copy)
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::NO_CONTENT
+        );
+
+        let req = test::TestRequest::post()
+            .uri("/paste_nodes")
+            .set_json(&(dest_id, (0.0, 0.0)))
+            .to_request();
+        assert_eq!(
+            app.call(req).await.unwrap().status(),
+            StatusCode::OK,
+            "pasting a reference together with its own target as siblings must still be allowed"
         );
     }
 }


### PR DESCRIPTION
closes #1113 